### PR TITLE
SCC / 2-SAT実装

### DIFF
--- a/AtCoderLibrary/Internal/InternalSCCGraph.cs
+++ b/AtCoderLibrary/Internal/InternalSCCGraph.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace AtCoder.Internal
+{
+    /// <summary>
+    /// 有向グラフを強連結成分分解します。
+    /// </summary>
+    [DebuggerDisplay("Vertices = {_n}, Edges = {edges.Count}")]
+    public class SCCGraph
+    {
+        private readonly int _n;
+        private readonly List<Edge> edges;
+
+        public int VerticesNumbers => _n;
+
+        /// <summary>
+        /// <see cref="SCCGraph"/> クラスの新しいインスタンスを、<paramref name="n"/> 頂点 0 辺の有向グラフとして初期化します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: 0≤<paramref name="n"/>≤10^8</para>
+        /// <para>計算量: O(<paramref name="n"/>)</para>
+        /// </remarks>
+        public SCCGraph(int n)
+        {
+            _n = n;
+            edges = new List<Edge>();
+        }
+
+        /// <summary>
+        /// 頂点 <paramref name="from"/> から頂点 <paramref name="to"/> へ有向辺を追加します。
+        /// </summary>
+        /// <remarks>
+        /// <para>制約: 0≤<paramref name="from"/>, <paramref name="to"/>&lt;n</para>
+        /// <para>計算量: ならしO(1)</para>
+        /// </remarks>
+        public void AddEdge(int from, int to) => edges.Add(new Edge(from, to));
+
+        /// <summary>
+        /// 強連結成分ごとに ID を割り振り、各頂点の所属する強連結成分の ID が記録された配列を取得します。
+        /// </summary>
+        /// <remarks>
+        /// <para>強連結成分の ID はトポロジカルソートされています。異なる強連結成分の頂点 u, v について、u から v に到達できる時、u の ID は v の ID よりも小さくなります。</para>
+        /// <para>計算量: 追加された辺の本数を m として O(n+m)</para>
+        /// </remarks>
+        public (int groupNum, int[] ids) SCCIDs()
+        {
+            // R. Tarjan のアルゴリズム
+            var g = new CSR(_n, edges);
+            int nowOrd = 0;
+            int groupNum = 0;
+            var visited = new Stack<int>(_n);
+            var low = new int[_n];
+            var ord = Enumerable.Repeat(-1, _n).ToArray();
+            var ids = new int[_n];
+
+            for (int i = 0; i < ord.Length; i++)
+            {
+                if (ord[i] == -1)
+                {
+                    DFS(i);
+                }
+            }
+
+            foreach (ref var x in ids.AsSpan())
+            {
+                // トポロジカル順序にするには逆順にする必要がある。
+                x = groupNum - 1 - x;
+            }
+
+            return (groupNum, ids);
+
+            void DFS(int v)
+            {
+                low[v] = nowOrd;
+                ord[v] = nowOrd++;
+                visited.Push(v);
+
+                // 頂点 v から伸びる有向辺を探索する。
+                for (int i = g.Start[v]; i < g.Start[v + 1]; i++)
+                {
+                    int to = g.EList[i];
+                    if (ord[to] == -1)
+                    {
+                        DFS(to);
+                        low[v] = System.Math.Min(low[v], low[to]);
+                    }
+                    else
+                    {
+                        low[v] = System.Math.Min(low[v], ord[to]);
+                    }
+                }
+
+                // v がSCCの根である場合、強連結成分に ID を割り振る。
+                if (low[v] == ord[v])
+                {
+                    while (true)
+                    {
+                        int u = visited.Pop();
+                        ord[u] = _n;
+                        ids[u] = groupNum;
+
+                        if (u == v)
+                        {
+                            break;
+                        }
+                    }
+
+                    groupNum++;
+                }
+            }
+        }
+
+        /// <summary>
+        /// 強連結成分分解の結果である「頂点のリスト」のリストを取得します。
+        /// </summary>
+        /// <remarks>
+        /// <para>- 全ての頂点がちょうど1つずつ、どれかのリストに含まれます。</para>
+        /// <para>- 内側のリストと強連結成分が一対一に対応します。リスト内での頂点の順序は未定義です。</para>
+        /// <para>- リストはトポロジカルソートされています。異なる強連結成分の頂点 u, v について、u から v に到達できる時、u の属するリストは v の属するリストよりも前です。</para>
+        /// <para>計算量: 追加された辺の本数を m として O(n+m)</para>
+        /// </remarks>
+        public List<List<int>> SCC()
+        {
+            var (groupNum, ids) = SCCIDs();
+            var counts = new int[groupNum];
+
+            foreach (var x in ids)
+            {
+                counts[x]++;
+            }
+
+            var groups = new List<List<int>>(groupNum);
+
+            for (int i = 0; i < groupNum; i++)
+            {
+                groups.Add(new List<int>(counts[i]));
+            }
+
+            for (int i = 0; i < ids.Length; i++)
+            {
+                groups[ids[i]].Add(i);
+            }
+
+            return groups;
+        }
+
+        /// <summary>
+        /// 有向グラフの辺集合を表します。
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// for (int i = graph.Starts[v]; i < graph.Starts[v + 1]; i++)
+        /// {
+        ///     int to = graph.Edges[i];
+        /// }
+        /// </code>
+        /// </example>
+        private class CSR
+        {
+            /// <summary>
+            /// 各頂点から伸びる有向辺数の累積和を取得します。
+            /// </summary>
+            public int[] Start { get; }
+
+            /// <summary>
+            /// 有向辺の終点の配列を取得します。
+            /// </summary>
+            public int[] EList { get; }
+
+            public CSR(int n, List<Edge> edges)
+            {
+                // 本家 C++ 版 ACL を参考に実装。通常の隣接リストと比較して高速か否かは未検証。
+                Start = new int[n + 1];
+                EList = new int[edges.Count];
+
+                foreach (var e in edges)
+                {
+                    Start[e.From + 1]++;
+                }
+
+                for (int i = 1; i <= n; i++)
+                {
+                    Start[i] += Start[i - 1];
+                }
+
+                var counter = new int[Start.Length];
+                Start.CopyTo(counter, 0);
+                foreach (var e in edges)
+                {
+                    EList[counter[e.From]++] = e.To;
+                }
+            }
+        }
+
+        [DebuggerDisplay("From = {From}, To = {To}")]
+        private readonly struct Edge
+        {
+            public int From { get; }
+            public int To { get; }
+
+            public Edge(int from, int to)
+            {
+                From = from;
+                To = to;
+            }
+        }
+    }
+}

--- a/AtCoderLibrary/Internal/InternalSCCGraph.cs
+++ b/AtCoderLibrary/Internal/InternalSCCGraph.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 
 namespace AtCoder.Internal
 {

--- a/AtCoderLibrary/SCCGraph.cs
+++ b/AtCoderLibrary/SCCGraph.cs
@@ -164,7 +164,7 @@ namespace AtCoder
             }
         }
 
-        [DebuggerDisplay("From:{From}, To:{To}")]
+        [DebuggerDisplay("From = {From}, To = {To}")]
         private readonly struct Edge
         {
             public int From { get; }

--- a/AtCoderLibrary/SCCGraph.cs
+++ b/AtCoderLibrary/SCCGraph.cs
@@ -7,11 +7,10 @@ namespace AtCoder
     /// <summary>
     /// 有向グラフを強連結成分分解します。
     /// </summary>
-    [DebuggerDisplay("Vertices = {_n}, Edges = {edges.Count}")]
+    [DebuggerDisplay("Vertices = {_internal._n}, Edges = {_internal.edges.Count}")]
     public class SCCGraph
     {
-        private readonly int _n;
-        private readonly List<Edge> edges;
+        Internal.SCCGraph _internal;
 
         /// <summary>
         /// <see cref="SCCGraph"/> クラスの新しいインスタンスを、<paramref name="n"/> 頂点 0 辺の有向グラフとして初期化します。
@@ -23,8 +22,7 @@ namespace AtCoder
         public SCCGraph(int n) 
         {
             Debug.Assert(unchecked((uint)n <= 100_000_000));
-            _n = n;
-            edges = new List<Edge>();
+            _internal = new Internal.SCCGraph(n);
         }
 
         /// <summary>
@@ -36,9 +34,10 @@ namespace AtCoder
         /// </remarks>
         public void AddEdge(int from, int to)
         {
-            Debug.Assert(unchecked((uint)from < _n));
-            Debug.Assert(unchecked((uint)to < _n));
-            edges.Add(new Edge(from, to));
+            int n = _internal.VerticesNumbers;
+            Debug.Assert(unchecked((uint)from < n));
+            Debug.Assert(unchecked((uint)to < n));
+            _internal.AddEdge(from, to);
         }
 
         /// <summary>
@@ -50,131 +49,6 @@ namespace AtCoder
         /// <para>- リストはトポロジカルソートされています。異なる強連結成分の頂点 u, v について、u から v に到達できる時、u の属するリストは v の属するリストよりも前です。</para>
         /// <para>計算量: 追加された辺の本数を m として O(n+m)</para>
         /// </remarks>
-        public List<List<int>> SCC() 
-        {
-            // R. Tarjan のアルゴリズム
-            var g = new CSR(_n, edges);
-            int nowOrd = 0;
-            var visited = new Stack<int>(_n);
-            var low = new int[_n];
-            var ord = Enumerable.Repeat(-1, _n).ToArray();
-
-            // 強連結成分分解結果
-            var sccs = new Stack<List<int>>();
-
-            for (int i = 0; i < ord.Length; i++)
-            {
-                if (ord[i] == -1)
-                {
-                    DFS(i);
-                }
-            }
-
-            // トポロジカル順序にするには逆順にする必要がある。
-            return sccs.ToList();
-
-            void DFS(int v)
-            {
-                low[v] = nowOrd;
-                ord[v] = nowOrd++;
-                visited.Push(v);
-                
-                // 頂点 v から伸びる有向辺を探索する。
-                for (int i = g.Start[v]; i < g.Start[v + 1]; i++)
-                {
-                    int to = g.EList[i];
-                    if (ord[to] == -1)
-                    {
-                        DFS(to);
-                        low[v] = System.Math.Min(low[v], low[to]);
-                    }
-                    else
-                    {
-                        low[v] = System.Math.Min(low[v], ord[to]);
-                    }
-                }
-
-                // v がSCCの根である場合、強連結成分を List に詰める。
-                if (low[v] == ord[v])
-                {
-                    var scc = new List<int>();
-
-                    while (true)
-                    {
-                        int u = visited.Pop();
-                        ord[u] = _n;
-                        scc.Add(u);
-
-                        if (u == v)
-                        {
-                            break;
-                        }
-                    }
-
-                    sccs.Push(scc);
-                }
-            }
-        }
-
-        /// <summary>
-        /// 有向グラフの辺集合を表します。
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// for (int i = graph.Starts[v]; i < graph.Starts[v + 1]; i++)
-        /// {
-        ///     int to = graph.Edges[i];
-        /// }
-        /// </code>
-        /// </example>
-        private class CSR
-        {
-            /// <summary>
-            /// 各頂点から伸びる有向辺数の累積和を取得します。
-            /// </summary>
-            public int[] Start { get; }
-
-            /// <summary>
-            /// 有向辺の終点の配列を取得します。
-            /// </summary>
-            public int[] EList { get; }
-
-            public CSR(int n, List<Edge> edges)
-            {
-                // 本家 C++ 版 ACL を参考に実装。通常の隣接リストと比較して高速か否かは未検証。
-                Start = new int[n + 1];
-                EList = new int[edges.Count];
-
-                foreach (var e in edges)
-                {
-                    Start[e.From + 1]++;
-                }
-
-                for (int i = 1; i <= n; i++)
-                {
-                    Start[i] += Start[i - 1];
-                }
-
-                var counter = new int[Start.Length];
-                Start.CopyTo(counter, 0);
-                foreach (var e in edges)
-                {
-                    EList[counter[e.From]++] = e.To;
-                }
-            }
-        }
-
-        [DebuggerDisplay("From = {From}, To = {To}")]
-        private readonly struct Edge
-        {
-            public int From { get; }
-            public int To { get; }
-
-            public Edge(int from, int to)
-            {
-                From = from;
-                To = to;
-            }
-        }
+        public List<List<int>> SCC() => _internal.SCC();
     }
 }

--- a/AtCoderLibrary/SCCGraph.cs
+++ b/AtCoderLibrary/SCCGraph.cs
@@ -7,17 +7,11 @@ namespace AtCoder
     /// <summary>
     /// 有向グラフを強連結成分分解します。
     /// </summary>
-    [DebuggerDisplay("Vertices = {VerticesCount}, Edges = {edges.Count}")]
+    [DebuggerDisplay("Vertices = {_n}, Edges = {edges.Count}")]
     public class SCCGraph
     {
-        // ひとまず C++ 版 ACL に合わせ、自動プロパティは使用しない。
         private readonly int _n;
         private readonly List<Edge> edges;
-
-        /// <summary>
-        /// 有向グラフの頂点数を取得します。
-        /// </summary>
-        public int VerticesCount => _n;
 
         /// <summary>
         /// <see cref="SCCGraph"/> クラスの新しいインスタンスを、<paramref name="n"/> 頂点 0 辺の有向グラフとして初期化します。

--- a/AtCoderLibrary/SCCGraph.cs
+++ b/AtCoderLibrary/SCCGraph.cs
@@ -1,14 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics;
 
 namespace AtCoder
 {
     /// <summary>
     /// 有向グラフを強連結成分分解します。
     /// </summary>
+    [DebuggerDisplay("Vertices = {VerticesCount}, Edges = {edges.Count}")]
     public class SCCGraph
     {
+        // ひとまず C++ 版 ACL に合わせ、自動プロパティは使用しない。
+        private readonly int _n;
+        private readonly List<Edge> edges;
+
+        /// <summary>
+        /// 有向グラフの頂点数を取得します。
+        /// </summary>
+        public int VerticesCount => _n;
+
         /// <summary>
         /// <see cref="SCCGraph"/> クラスの新しいインスタンスを、<paramref name="n"/> 頂点 0 辺の有向グラフとして初期化します。
         /// </summary>
@@ -16,7 +26,12 @@ namespace AtCoder
         /// <para>制約: 0≤<paramref name="n"/>≤10^8</para>
         /// <para>計算量: O(<paramref name="n"/>)</para>
         /// </remarks>
-        public SCCGraph(int n) { throw new NotImplementedException(); }
+        public SCCGraph(int n) 
+        {
+            Debug.Assert(unchecked((uint)n <= 100_000_000));
+            _n = n;
+            edges = new List<Edge>();
+        }
 
         /// <summary>
         /// 頂点 <paramref name="from"/> から頂点 <paramref name="to"/> へ有向辺を追加します。
@@ -25,7 +40,12 @@ namespace AtCoder
         /// <para>制約: 0≤<paramref name="from"/>, <paramref name="to"/>&lt;n</para>
         /// <para>計算量: ならしO(1)</para>
         /// </remarks>
-        public void AddEdge(int from, int to) { throw new NotImplementedException(); }
+        public void AddEdge(int from, int to)
+        {
+            Debug.Assert(unchecked((uint)from < _n));
+            Debug.Assert(unchecked((uint)to < _n));
+            edges.Add(new Edge(from, to));
+        }
 
         /// <summary>
         /// 強連結成分分解の結果である「頂点のリスト」のリストを取得します。
@@ -36,6 +56,131 @@ namespace AtCoder
         /// <para>- リストはトポロジカルソートされています。異なる強連結成分の頂点 u, v について、u から v に到達できる時、u の属するリストは v の属するリストよりも前です。</para>
         /// <para>計算量: 追加された辺の本数を m として O(n+m)</para>
         /// </remarks>
-        public List<List<int>> SCC() { throw new Exception(); }
+        public List<List<int>> SCC() 
+        {
+            // R. Tarjan のアルゴリズム
+            var g = new CSR(_n, edges);
+            int nowOrd = 0;
+            var visited = new Stack<int>(_n);
+            var low = new int[_n];
+            var ord = Enumerable.Repeat(-1, _n).ToArray();
+
+            // 強連結成分分解結果
+            var sccs = new Stack<List<int>>();
+
+            for (int i = 0; i < ord.Length; i++)
+            {
+                if (ord[i] == -1)
+                {
+                    DFS(i);
+                }
+            }
+
+            // トポロジカル順序にするには逆順にする必要がある。
+            return sccs.ToList();
+
+            void DFS(int v)
+            {
+                low[v] = nowOrd;
+                ord[v] = nowOrd++;
+                visited.Push(v);
+                
+                // 頂点 v から伸びる有向辺を探索する。
+                for (int i = g.Start[v]; i < g.Start[v + 1]; i++)
+                {
+                    int to = g.EList[i];
+                    if (ord[to] == -1)
+                    {
+                        DFS(to);
+                        low[v] = System.Math.Min(low[v], low[to]);
+                    }
+                    else
+                    {
+                        low[v] = System.Math.Min(low[v], ord[to]);
+                    }
+                }
+
+                // v がSCCの根である場合、強連結成分を List に詰める。
+                if (low[v] == ord[v])
+                {
+                    var scc = new List<int>();
+
+                    while (true)
+                    {
+                        int u = visited.Pop();
+                        ord[u] = _n;
+                        scc.Add(u);
+
+                        if (u == v)
+                        {
+                            break;
+                        }
+                    }
+
+                    sccs.Push(scc);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 有向グラフの辺集合を表します。
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// for (int i = graph.Starts[v]; i < graph.Starts[v + 1]; i++)
+        /// {
+        ///     int to = graph.Edges[i];
+        /// }
+        /// </code>
+        /// </example>
+        private class CSR
+        {
+            /// <summary>
+            /// 各頂点から伸びる有向辺数の累積和を取得します。
+            /// </summary>
+            public int[] Start { get; }
+
+            /// <summary>
+            /// 有向辺の終点の配列を取得します。
+            /// </summary>
+            public int[] EList { get; }
+
+            public CSR(int n, List<Edge> edges)
+            {
+                // 本家 C++ 版 ACL を参考に実装。通常の隣接リストと比較して高速か否かは未検証。
+                Start = new int[n + 1];
+                EList = new int[edges.Count];
+
+                foreach (var e in edges)
+                {
+                    Start[e.From + 1]++;
+                }
+
+                for (int i = 1; i <= n; i++)
+                {
+                    Start[i] += Start[i - 1];
+                }
+
+                var counter = new int[Start.Length];
+                Start.CopyTo(counter, 0);
+                foreach (var e in edges)
+                {
+                    EList[counter[e.From]++] = e.To;
+                }
+            }
+        }
+
+        [DebuggerDisplay("From:{From}, To:{To}")]
+        private readonly struct Edge
+        {
+            public int From { get; }
+            public int To { get; }
+
+            public Edge(int from, int to)
+            {
+                From = from;
+                To = to;
+            }
+        }
     }
 }

--- a/AtCoderLibrary/SCCGraph.cs
+++ b/AtCoderLibrary/SCCGraph.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Diagnostics;
 
 namespace AtCoder

--- a/AtCoderLibrary/TwoSat.cs
+++ b/AtCoderLibrary/TwoSat.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Diagnostics;
 
 namespace AtCoder
 {
@@ -10,15 +8,26 @@ namespace AtCoder
     /// 変数 x_0, x_1,…, x_{n-1} に関して (x_i=f)∨(x_j=g) というクローズを足し、これをすべて満たす変数の割当があるかを解きます。
     /// </para>
     /// </summary>
+    [DebuggerDisplay("Count = {_n}")]
     public class TwoSat
     {
+        readonly int _n;
+        readonly private bool[] _answer;
+        readonly private SCCGraph scc;
+
         /// <summary>
         /// <see cref="TwoSat"/> クラスの新しいインスタンスを、<paramref name="n"/> 変数の 2-SAT として初期化します。
         /// </summary>
         /// <remarks>
         /// <para>制約 : 0≤<paramref name="n"/>≤10^8</para>
         /// </remarks>
-        public TwoSat(int n) { throw new NotImplementedException(); }
+        public TwoSat(int n) 
+        {
+            Debug.Assert(unchecked((uint)n <= 100_000_000));
+            _n = n;
+            _answer = new bool[n];
+            scc = new SCCGraph(2 * n);
+        }
 
         /// <summary>
         /// (x_<paramref name="i"/>=<paramref name="f"/>)∨(x_<paramref name="j"/>=<paramref name="g"/>) というクローズを追加します。
@@ -27,17 +36,50 @@ namespace AtCoder
         /// <para>制約: 0≤<paramref name="i"/>&lt;n, 0≤<paramref name="j"/>&lt;n</para>
         /// <para>計算量: ならし O(1)</para>
         /// </remarks>
-        public void AddClause(int i, bool f, int j, bool g) { throw new NotImplementedException(); }
+        public void AddClause(int i, bool f, int j, bool g) 
+        {
+            Debug.Assert(unchecked((uint)i < _n));
+            Debug.Assert(unchecked((uint)j < _n));
+            scc.AddEdge(2 * i + (f ? 0 : 1), 2 * j + (g ? 1 : 0));
+            scc.AddEdge(2 * j + (g ? 0 : 1), 2 * i + (f ? 1 : 0));
+        }
 
         /// <summary>
-        /// 条件を足す割当が存在するかどうかを判定します。
+        /// 条件を満たす割当が存在するかどうかを判定します。
         /// </summary>
         /// <remarks>
         /// <para>制約: 複数回呼ぶことも可能。</para>
         /// <para>計算量: 足した制約の個数を m として O(n+m)</para>
         /// </remarks>
         /// <returns>割当が存在するならば <c>true</c>、そうでないなら <c>false</c>。</returns>
-        public bool Satisfiable() { throw new Exception(); }
+        public bool Satisfiable() 
+        {
+            var sccs = scc.SCC();
+            var id = new int[2 * _n];
+
+            // 強連結成分のリストを id として展開。
+            for (int i = 0; i < sccs.Count; i++)
+            {
+                foreach (var v in sccs[i])
+                {
+                    id[v] = i;
+                }
+            }
+
+            for (int i = 0; i < _n; i++)
+            {
+                if (id[2 * i] == id[2 * i + 1])
+                {
+                    return false;
+                }
+                else
+                {
+                    _answer[i] = id[2 * i] < id[2 * i + 1];
+                }
+            }
+
+            return true;
+        }
 
         /// <summary>
         /// 最後に実行した <see cref="Satisfiable"/> の、クローズを満たす割当を返します。実行前や、割当が存在しなかった場合は中身が未定義の長さ n の配列を返します。
@@ -46,6 +88,6 @@ namespace AtCoder
         /// <para>計算量: O(n)</para>
         /// </remarks>
         /// <returns>最後に呼んだ <see cref="Satisfiable"/> の、クローズを満たす割当の配列。</returns>
-        public bool[] Answer() { throw new Exception(); }
+        public bool[] Answer() => _answer;
     }
 }


### PR DESCRIPTION
SCCおよび2-SATを実装しました。 #16 #17 

基本的にC++版と概ね同様のコードとしていますが、
`SCCGraph.SCC()`の以下の仕様変更に合わせて、一部処理を変更しています。
- C++版：各頂点が属する強連結成分のグループID配列を返す。
- C#版：強連結成分分解の結果である「頂点のリスト」のリストを返す。

変更内容
- `SCCGraph.SCC()`内にて、「頂点のリスト」のリストを保存するための変数`Stack<List<int>> sccs`を追加。
- `TwoSat.Satisfiable()`内にて、受け取ったリストを強連結成分のグループID配列に展開するコードを追加。

以下の提出にて動作確認を行っています。
SCC: https://atcoder.jp/contests/practice2/submissions/16599658
2-SAT: https://atcoder.jp/contests/practice2/submissions/16598595

気付き点等あればコメント頂けると嬉しいです。よろしくお願いします。