### PR TITLE
String.SuffixArray<T>(ReadOnlySpan<T> s)をprivate化

### DIFF
--- a/AtCoderLibrary/String/SuffixArray.cs
+++ b/AtCoderLibrary/String/SuffixArray.cs
@@ -14,7 +14,7 @@ namespace AtCoder
         /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
         /// <para>計算量: 時間O(|<paramref name="s"/>|log|<paramref name="s"/>|), 空間O(|<paramref name="s"/>|)</para>
         /// </remarks>
-        public static int[] SuffixArray<T>(ReadOnlySpan<T> s) { throw new NotImplementedException(); }
+        public static int[] SuffixArray<T>(ReadOnlyMemory<T> s) { throw new NotImplementedException(); }
 
         /// <summary>
         /// 文字列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。
@@ -24,7 +24,7 @@ namespace AtCoder
         /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
         /// <para>計算量: O(|<paramref name="s"/>|)</para>
         /// </remarks>
-        public static int[] SuffixArray(string s) => SuffixArray(s.AsSpan());
+        public static int[] SuffixArray(string s) => SuffixArray(s.AsMemory());
 
         /// <summary>
         /// 数列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。
@@ -34,7 +34,7 @@ namespace AtCoder
         /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
         /// <para>計算量: 時間O(|<paramref name="s"/>|log|<paramref name="s"/>|), 空間O(|<paramref name="s"/>|)</para>
         /// </remarks>
-        public static int[] SuffixArray(int[] s) => SuffixArray((ReadOnlySpan<int>)s);
+        public static int[] SuffixArray(int[] s) => SuffixArray<int>(s.AsMemory());
         /// <summary>
         /// 数列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。
         /// </summary>
@@ -43,7 +43,7 @@ namespace AtCoder
         /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
         /// <para>計算量: 時間O(|<paramref name="s"/>|log|<paramref name="s"/>|), 空間O(|<paramref name="s"/>|)</para>
         /// </remarks>
-        public static int[] SuffixArray(uint[] s) => SuffixArray((ReadOnlySpan<uint>)s);
+        public static int[] SuffixArray(uint[] s) => SuffixArray<uint>(s.AsMemory());
         /// <summary>
         /// 数列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。
         /// </summary>
@@ -52,7 +52,7 @@ namespace AtCoder
         /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
         /// <para>計算量: 時間O(|<paramref name="s"/>|log|<paramref name="s"/>|), 空間O(|<paramref name="s"/>|)</para>
         /// </remarks>
-        public static int[] SuffixArray(long[] s) => SuffixArray((ReadOnlySpan<long>)s);
+        public static int[] SuffixArray(long[] s) => SuffixArray<long>(s.AsMemory());
         /// <summary>
         /// 数列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。
         /// </summary>
@@ -61,7 +61,7 @@ namespace AtCoder
         /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
         /// <para>計算量: 時間O(|<paramref name="s"/>|log|<paramref name="s"/>|), 空間O(|<paramref name="s"/>|)</para>
         /// </remarks>
-        public static int[] SuffixArray(ulong[] s) => SuffixArray((ReadOnlySpan<ulong>)s);
+        public static int[] SuffixArray(ulong[] s) => SuffixArray<ulong>(s.AsMemory());
 
         /// <summary>
         /// 数列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。

--- a/AtCoderLibrary/String/SuffixArray.cs
+++ b/AtCoderLibrary/String/SuffixArray.cs
@@ -14,7 +14,7 @@ namespace AtCoder
         /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
         /// <para>計算量: 時間O(|<paramref name="s"/>|log|<paramref name="s"/>|), 空間O(|<paramref name="s"/>|)</para>
         /// </remarks>
-        public static int[] SuffixArray<T>(ReadOnlyMemory<T> s) { throw new NotImplementedException(); }
+        private static int[] SuffixArray<T>(ReadOnlyMemory<T> s) { throw new NotImplementedException(); }
 
         /// <summary>
         /// 文字列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。
@@ -34,34 +34,7 @@ namespace AtCoder
         /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
         /// <para>計算量: 時間O(|<paramref name="s"/>|log|<paramref name="s"/>|), 空間O(|<paramref name="s"/>|)</para>
         /// </remarks>
-        public static int[] SuffixArray(int[] s) => SuffixArray<int>(s.AsMemory());
-        /// <summary>
-        /// 数列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。
-        /// </summary>
-        /// <remarks>
-        /// <para>Suffix Array sa は (0,1,…,n−1) の順列であって、i=0,1,⋯,n−2 について s[sa[i]..n)&lt;s[sa[i+1]..n) を満たすもの。</para>
-        /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
-        /// <para>計算量: 時間O(|<paramref name="s"/>|log|<paramref name="s"/>|), 空間O(|<paramref name="s"/>|)</para>
-        /// </remarks>
-        public static int[] SuffixArray(uint[] s) => SuffixArray<uint>(s.AsMemory());
-        /// <summary>
-        /// 数列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。
-        /// </summary>
-        /// <remarks>
-        /// <para>Suffix Array sa は (0,1,…,n−1) の順列であって、i=0,1,⋯,n−2 について s[sa[i]..n)&lt;s[sa[i+1]..n) を満たすもの。</para>
-        /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
-        /// <para>計算量: 時間O(|<paramref name="s"/>|log|<paramref name="s"/>|), 空間O(|<paramref name="s"/>|)</para>
-        /// </remarks>
-        public static int[] SuffixArray(long[] s) => SuffixArray<long>(s.AsMemory());
-        /// <summary>
-        /// 数列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。
-        /// </summary>
-        /// <remarks>
-        /// <para>Suffix Array sa は (0,1,…,n−1) の順列であって、i=0,1,⋯,n−2 について s[sa[i]..n)&lt;s[sa[i+1]..n) を満たすもの。</para>
-        /// <para>制約: 0≤|<paramref name="s"/>|&lt;10^8</para>
-        /// <para>計算量: 時間O(|<paramref name="s"/>|log|<paramref name="s"/>|), 空間O(|<paramref name="s"/>|)</para>
-        /// </remarks>
-        public static int[] SuffixArray(ulong[] s) => SuffixArray<ulong>(s.AsMemory());
+        public static int[] SuffixArray<T>(T[] s) => SuffixArray<T>(s.AsMemory());
 
         /// <summary>
         /// 数列 <paramref name="s"/> の Suffix Array として、長さ |<paramref name="s"/>| の配列を返す。


### PR DESCRIPTION
`ReadOnlySpan<T>`はローカル関数やラムダ式でキャプチャできないことを失念していました……。
`ReadOnlyMemory<T>`なら回避できるのでそちらに変更しようと考えておりますが、いかがでしょうか？
他のオーバーロード（`string`, `int[]`等）の引数には変更ありません。
#4 #26 