### PR TITLE
MinCostFlow 実装

### DIFF
--- a/AtCoderLibrary/Algebra/NumOperator.cs
+++ b/AtCoderLibrary/Algebra/NumOperator.cs
@@ -45,6 +45,16 @@ namespace AtCoder
         /// <returns>-<paramref name="x"/></returns>
         T Minus(T x);
         /// <summary>
+        /// Increment operator ++
+        /// </summary>
+        /// <returns>++<paramref name="x"/></returns>
+        T Increment(T x);
+        /// <summary>
+        /// Decrement operator --
+        /// </summary>
+        /// <returns>--<paramref name="x"/></returns>
+        T Decrement(T x);
+        /// <summary>
         /// Greater than operator &gt;
         /// </summary>
         /// <returns><paramref name="x"/> &gt; <paramref name="y"/></returns>
@@ -75,6 +85,8 @@ namespace AtCoder
         public int Divide(int x, int y) => x / y;
         public int Modulo(int x, int y) => x % y;
         public int Minus(int x) => -x;
+        public int Increment(int x) => ++x;
+        public int Decrement(int x) => --x;
         public bool GreaterThan(int x, int y) => x > y;
         public bool GreaterThanOrEqual(int x, int y) => x >= y;
         public bool LessThan(int x, int y) => x < y;
@@ -93,6 +105,8 @@ namespace AtCoder
         public long Divide(long x, long y) => x / y;
         public long Modulo(long x, long y) => x % y;
         public long Minus(long x) => -x;
+        public long Increment(long x) => ++x;
+        public long Decrement(long x) => --x;
         public bool GreaterThan(long x, long y) => x > y;
         public bool GreaterThanOrEqual(long x, long y) => x >= y;
         public bool LessThan(long x, long y) => x < y;
@@ -111,6 +125,8 @@ namespace AtCoder
         public uint Divide(uint x, uint y) => x / y;
         public uint Modulo(uint x, uint y) => x % y;
         public uint Minus(uint x) => throw new InvalidOperationException("Uint type cannot be negative.");
+        public uint Increment(uint x) => ++x;
+        public uint Decrement(uint x) => --x;
         public bool GreaterThan(uint x, uint y) => x > y;
         public bool GreaterThanOrEqual(uint x, uint y) => x >= y;
         public bool LessThan(uint x, uint y) => x < y;
@@ -129,6 +145,8 @@ namespace AtCoder
         public ulong Divide(ulong x, ulong y) => x / y;
         public ulong Modulo(ulong x, ulong y) => x % y;
         public ulong Minus(ulong x) => throw new InvalidOperationException("Ulong type cannot be negative.");
+        public ulong Increment(ulong x) => ++x;
+        public ulong Decrement(ulong x) => --x;
         public bool GreaterThan(ulong x, ulong y) => x > y;
         public bool GreaterThanOrEqual(ulong x, ulong y) => x >= y;
         public bool LessThan(ulong x, ulong y) => x < y;
@@ -147,6 +165,8 @@ namespace AtCoder
         public double Divide(double x, double y) => x / y;
         public double Modulo(double x, double y) => x % y;
         public double Minus(double x) => -x;
+        public double Increment(double x) => ++x;
+        public double Decrement(double x) => --x;
         public bool GreaterThan(double x, double y) => x > y;
         public bool GreaterThanOrEqual(double x, double y) => x >= y;
         public bool LessThan(double x, double y) => x < y;

--- a/AtCoderLibrary/Algebra/NumOperator.cs
+++ b/AtCoderLibrary/Algebra/NumOperator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace AtCoder
 {
@@ -39,6 +40,11 @@ namespace AtCoder
         /// <returns><paramref name="x"/> % <paramref name="y"/></returns>
         T Modulo(T x, T y);
         /// <summary>
+        /// Unary minus operator -
+        /// </summary>
+        /// <returns>-<paramref name="x"/></returns>
+        T Minus(T x);
+        /// <summary>
         /// Greater than operator &gt;
         /// </summary>
         /// <returns><paramref name="x"/> &gt; <paramref name="y"/></returns>
@@ -68,6 +74,7 @@ namespace AtCoder
         public int Multiply(int x, int y) => x * y;
         public int Divide(int x, int y) => x / y;
         public int Modulo(int x, int y) => x % y;
+        public int Minus(int x) => -x;
         public bool GreaterThan(int x, int y) => x > y;
         public bool GreaterThanOrEqual(int x, int y) => x >= y;
         public bool LessThan(int x, int y) => x < y;
@@ -85,6 +92,7 @@ namespace AtCoder
         public long Multiply(long x, long y) => x * y;
         public long Divide(long x, long y) => x / y;
         public long Modulo(long x, long y) => x % y;
+        public long Minus(long x) => -x;
         public bool GreaterThan(long x, long y) => x > y;
         public bool GreaterThanOrEqual(long x, long y) => x >= y;
         public bool LessThan(long x, long y) => x < y;
@@ -102,6 +110,7 @@ namespace AtCoder
         public uint Multiply(uint x, uint y) => x * y;
         public uint Divide(uint x, uint y) => x / y;
         public uint Modulo(uint x, uint y) => x % y;
+        public uint Minus(uint x) => throw new InvalidOperationException("Uint type cannot be negative.");
         public bool GreaterThan(uint x, uint y) => x > y;
         public bool GreaterThanOrEqual(uint x, uint y) => x >= y;
         public bool LessThan(uint x, uint y) => x < y;
@@ -119,6 +128,7 @@ namespace AtCoder
         public ulong Multiply(ulong x, ulong y) => x * y;
         public ulong Divide(ulong x, ulong y) => x / y;
         public ulong Modulo(ulong x, ulong y) => x % y;
+        public ulong Minus(ulong x) => throw new InvalidOperationException("Ulong type cannot be negative.");
         public bool GreaterThan(ulong x, ulong y) => x > y;
         public bool GreaterThanOrEqual(ulong x, ulong y) => x >= y;
         public bool LessThan(ulong x, ulong y) => x < y;
@@ -136,6 +146,7 @@ namespace AtCoder
         public double Multiply(double x, double y) => x * y;
         public double Divide(double x, double y) => x / y;
         public double Modulo(double x, double y) => x % y;
+        public double Minus(double x) => -x;
         public bool GreaterThan(double x, double y) => x > y;
         public bool GreaterThanOrEqual(double x, double y) => x >= y;
         public bool LessThan(double x, double y) => x < y;

--- a/AtCoderLibrary/MaxFlow.cs
+++ b/AtCoderLibrary/MaxFlow.cs
@@ -83,6 +83,7 @@ namespace AtCoder
         /// </summary>
         /// <remarks>
         /// <para>AddEdge で <paramref name="i"/> 番目 (0-indexed) に追加された辺を返す。</para>
+        /// <para>制約: m を追加された辺数として 0 ≤ i &lt; m</para>
         /// <para>計算量: O(1)</para>
         /// </remarks>
         public Edge GetEdge(int i)
@@ -99,7 +100,7 @@ namespace AtCoder
         /// </summary>
         /// <remarks>
         /// <para>辺の順番はadd_edgeで追加された順番と同一。</para>
-        /// <para>計算量: O(n)</para>
+        /// <para>計算量: m を追加された辺数として O(m)</para>
         /// </remarks>
         public List<Edge> Edges()
         {

--- a/AtCoderLibrary/MinCostFlow.cs
+++ b/AtCoderLibrary/MinCostFlow.cs
@@ -1,0 +1,298 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace AtCoder
+{
+    public class McfGraph<TCap, TCapOp, TCost, TCostOp>
+        where TCap : struct
+        where TCapOp : struct, INumOperator<TCap>
+        where TCost : struct
+        where TCostOp : struct, INumOperator<TCost>
+    {
+        static readonly TCapOp capOp = default;
+        static readonly TCostOp costOp = default;
+
+        public McfGraph(int n)
+        {
+            _n = n;
+            _g = new List<EdgeInternal>[n];
+            for (int i = 0; i < n; i++)
+            {
+                _g[i] = new List<EdgeInternal>();
+            }
+            _pos = new List<(int first, int second)>();
+        }
+
+        public int AddEdge(int from, int to, TCap cap, TCost cost)
+        {
+            Debug.Assert(0 <= from && from < _n);
+            Debug.Assert(0 <= to && to < _n);
+            int m = _pos.Count;
+            _pos.Add((from, _g[from].Count));
+            _g[from].Add(new EdgeInternal(to, _g[to].Count, cap, cost));
+            _g[to].Add(new EdgeInternal(from, _g[from].Count - 1, default, costOp.Minus(cost)));
+            return m;
+        }
+
+        public Edge GetEdge(int i)
+        {
+            int m = _pos.Count;
+            Debug.Assert(0 <= i && i < m);
+            var _e = _g[_pos[i].first][_pos[i].second];
+            var _re = _g[_e.To][_e.Rev];
+            return new Edge(_pos[i].first, _e.To, capOp.Add(_e.Cap, _re.Cap), _re.Cap, _e.Cost);
+        }
+
+        public List<Edge> Edges()
+        {
+            int m = _pos.Count;
+            var result = new List<Edge>();
+            for (int i = 0; i < m; i++)
+            {
+                result.Add(GetEdge(i));
+            }
+            return result;
+        }
+
+        public (TCap cap, TCost cost) Flow(int s, int t)
+        {
+            return flow(s, t, capOp.MaxValue);
+        }
+        public (TCap cap, TCost cost) flow(int s, int t, TCap flow_limit)
+        {
+            return Slope(s, t, flow_limit).Last();
+        }
+        public List<(TCap cap, TCost cost)> Slope(int s, int t)
+        {
+            return Slope(s, t, capOp.MaxValue);
+        }
+
+        public List<(TCap cap, TCost cost)> Slope(int s, int t, TCap flow_limit)
+        {
+            Debug.Assert(0 <= s && s < _n);
+            Debug.Assert(0 <= t && t < _n);
+            Debug.Assert(s != t);
+            // variants (C = maxcost):
+            // -(n-1)C <= dual[s] <= dual[i] <= dual[t] = 0
+            // reduced cost (= e.cost + dual[e.from] - dual[e.to]) >= 0 for all edge
+            var dual = new TCost[_n];
+            var dist = new TCost[_n];
+            var pv = new int[_n];
+            var pe = new int[_n];
+            var vis = new bool[_n];
+
+            bool DualRef()
+            {
+                dist.AsSpan().Fill(costOp.MaxValue);
+                pv.AsSpan().Fill(-1);
+                pe.AsSpan().Fill(-1);
+                vis.AsSpan().Fill(false);
+
+                var que = new PriorityQueueForMcf();
+                dist[s] = default;
+                que.Enqueue(default, s);
+                while (que.Count > 0)
+                {
+                    int v = que.Dequeue().to;
+                    if(vis[v]) continue;
+                    vis[v] = true;
+                    if(v == t) break;
+                    // dist[v] = shortest(s, v) + dual[s] - dual[v]
+                    // dist[v] >= 0 (all reduced cost are positive)
+                    // dist[v] <= (n-1)C
+                    for (int i = 0; i < _g[v].Count; i++)
+                    {
+                        var e = _g[v][i];
+                        if(vis[e.To] || capOp.Equals(e.Cap, default)) continue;
+                        // |-dual[e.to] + dual[v]| <= (n-1)C
+                        // cost <= C - -(n-1)C + 0 = nC
+                        TCost cost = costOp.Add(costOp.Subtract(e.Cost, dual[e.To]), dual[v]);
+                        if (costOp.GreaterThan(costOp.Subtract(dist[e.To], dist[v]), cost)) {
+                            dist[e.To] = costOp.Add(dist[v], cost);
+                            pv[e.To] = v;
+                            pe[e.To] = i;
+                            que.Enqueue(dist[e.To], e.To);
+                        }
+                    }
+                }
+
+                if (!vis[t])
+                {
+                    return false;
+                }
+
+                for (int v = 0; v < _n; v++)
+                {
+                    if (!vis[v]) continue;
+                    // dual[v] = dual[v] - dist[t] + dist[v]
+                    //         = dual[v] - (shortest(s, t) + dual[s] - dual[t]) + (shortest(s, v) + dual[s] - dual[v])
+                    //         = - shortest(s, t) + dual[t] + shortest(s, v)
+                    //         = shortest(s, v) - shortest(s, t) >= 0 - (n-1)C
+                    dual[v] = costOp.Subtract(dual[v], costOp.Subtract(dist[t], dist[v]));
+                }
+
+                return true;
+            }
+
+            TCap flow = default;
+            TCost cost = default;
+            TCost prev_cost = costOp.Decrement(default); //-1
+            var result = new List<(TCap cap, TCost cost)>();
+            result.Add((flow, cost));
+            while (capOp.LessThan(flow, flow_limit))
+            {
+                if (!DualRef()) break;
+                TCap c = capOp.Subtract(flow_limit, flow);
+                for (int v = t; v != s; v = pv[v])
+                {
+                    if (capOp.LessThan(_g[pv[v]][pe[v]].Cap, c))
+                    {
+                        c = _g[pv[v]][pe[v]].Cap;
+                    }
+                }
+                for (int v = t; v != s; v = pv[v])
+                {
+                    _g[pv[v]][pe[v]].Cap = capOp.Subtract(_g[pv[v]][pe[v]].Cap, c);
+                    _g[v][_g[pv[v]][pe[v]].Rev].Cap = capOp.Add(_g[v][_g[pv[v]][pe[v]].Rev].Cap, c);
+                }
+                TCost d = costOp.Minus(dual[s]);
+                flow = capOp.Add(flow, c);
+                cost = costOp.Add(cost, costOp.Multiply(c, d));
+                if (costOp.Equals(prev_cost, d))
+                {
+                    result.RemoveAt(result.Count - 1);
+                }
+                result.Add((flow, cost));
+                prev_cost = cost;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// フローを流すグラフの各辺に対応した情報を持ちます。
+        /// </summary>
+        public struct Edge
+        {
+            /// <summary>フローが流出する頂点。</summary>
+            public int From { get; set; }
+            /// <summary>フローが流入する頂点。</summary>
+            public int To { get; set; }
+            /// <summary>辺の容量。</summary>
+            public TCap Cap { get; set; }
+            /// <summary>辺の流量。</summary>
+            public TCap Flow { get; set; }
+            /// <summary>辺の費用</summary>
+            public TCost Cost { get; set; }
+            public Edge(int from, int to, TCap cap, TCap flow, TCost cost)
+            {
+                From = from;
+                To = to;
+                Cap = cap;
+                Flow = flow;
+                Cost = cost;
+            }
+        };
+
+        private class EdgeInternal
+        {
+            public int To { get; set; }
+            public int Rev { get; set; }
+            public TCap Cap { get; set; }
+            public TCost Cost { get; set; }
+            public EdgeInternal(int to, int rev, TCap cap, TCost cost)
+            {
+                To = to;
+                Rev = rev;
+                Cap = cap;
+                Cost = cost;
+            }
+        };
+
+        private readonly int _n;
+        private readonly List<(int first, int second)> _pos;
+        private readonly List<EdgeInternal>[] _g;
+
+        private class PriorityQueueForMcf
+        {
+            private (TCost cost, int to)[] _heap;
+
+            public int Count { get; private set; } = 0;
+            public PriorityQueueForMcf()
+            {
+                _heap = new (TCost cost, int to)[1024];
+            }
+
+            public void Enqueue(TCost cost, int to)
+            {
+                var pair = (cost, to);
+                if (_heap.Length == Count)
+                {
+                    var newHeap = new (TCost cost, int to)[_heap.Length * 2];
+                    _heap.CopyTo(newHeap, 0);
+                    _heap = newHeap;
+                }
+
+                _heap[Count] = pair;
+                ++Count;
+
+                int c = Count - 1;
+                while (c > 0)
+                {
+                    int p = (c - 1) >> 1;
+                    if (Compare(_heap[p].cost, cost) < 0)
+                    {
+                        _heap[c] = _heap[p];
+                        c = p;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                _heap[c] = pair;
+            }
+
+            public (TCost cost, int to) Dequeue()
+            {
+                (TCost cost, int to) ret = _heap[0];
+                int n = Count - 1;
+
+                var item = _heap[n];
+                int p = 0;
+                int c = (p << 1) + 1;
+                while (c < n)
+                {
+                    if (c != n - 1 && Compare(_heap[c + 1].cost, _heap[c].cost) > 0)
+                    {
+                        ++c;
+                    }
+
+                    if (Compare(item.cost, _heap[c].cost) < 0)
+                    {
+                        _heap[p] = _heap[c];
+                        p = c;
+                        c = (p << 1) + 1;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                _heap[p] = item;
+                Count--;
+
+                return ret;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private int Compare(TCost x, TCost y) => costOp.Compare(y, x);
+        }
+    }
+}

--- a/AtCoderLibrary/MinCostFlow.cs
+++ b/AtCoderLibrary/MinCostFlow.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace AtCoder
 {
@@ -268,20 +266,21 @@ namespace AtCoder
                 while (que.Count > 0)
                 {
                     int v = que.Dequeue().to;
-                    if(vis[v]) continue;
+                    if (vis[v]) continue;
                     vis[v] = true;
-                    if(v == t) break;
+                    if (v == t) break;
                     // dist[v] = shortest(s, v) + dual[s] - dual[v]
                     // dist[v] >= 0 (all reduced cost are positive)
                     // dist[v] <= (n-1)C
                     for (int i = 0; i < _g[v].Count; i++)
                     {
                         var e = _g[v][i];
-                        if(vis[e.To] || op.Equals(e.Cap, default)) continue;
+                        if (vis[e.To] || op.Equals(e.Cap, default)) continue;
                         // |-dual[e.to] + dual[v]| <= (n-1)C
                         // cost <= C - -(n-1)C + 0 = nC
                         TValue cost = op.Add(op.Subtract(e.Cost, dual[e.To]), dual[v]);
-                        if (op.GreaterThan(op.Subtract(dist[e.To], dist[v]), cost)) {
+                        if (op.GreaterThan(op.Subtract(dist[e.To], dist[v]), cost))
+                        {
                             dist[e.To] = op.Add(dist[v], cost);
                             pv[e.To] = v;
                             pe[e.To] = i;

--- a/AtCoderLibrary/MinCostFlow.cs
+++ b/AtCoderLibrary/MinCostFlow.cs
@@ -8,14 +8,11 @@ using System.Text;
 
 namespace AtCoder
 {
-    public class McfGraph<TCap, TCapOp, TCost, TCostOp>
-        where TCap : struct
-        where TCapOp : struct, INumOperator<TCap>
-        where TCost : struct
-        where TCostOp : struct, INumOperator<TCost>
+    public class McfGraph<TValue, TOp>
+        where TValue : struct
+        where TOp : struct, INumOperator<TValue>
     {
-        static readonly TCapOp capOp = default;
-        static readonly TCostOp costOp = default;
+        static readonly TOp op = default;
 
         public McfGraph(int n)
         {
@@ -28,14 +25,14 @@ namespace AtCoder
             _pos = new List<(int first, int second)>();
         }
 
-        public int AddEdge(int from, int to, TCap cap, TCost cost)
+        public int AddEdge(int from, int to, TValue cap, TValue cost)
         {
             Debug.Assert(0 <= from && from < _n);
             Debug.Assert(0 <= to && to < _n);
             int m = _pos.Count;
             _pos.Add((from, _g[from].Count));
             _g[from].Add(new EdgeInternal(to, _g[to].Count, cap, cost));
-            _g[to].Add(new EdgeInternal(from, _g[from].Count - 1, default, costOp.Minus(cost)));
+            _g[to].Add(new EdgeInternal(from, _g[from].Count - 1, default, op.Minus(cost)));
             return m;
         }
 
@@ -45,7 +42,7 @@ namespace AtCoder
             Debug.Assert(0 <= i && i < m);
             var _e = _g[_pos[i].first][_pos[i].second];
             var _re = _g[_e.To][_e.Rev];
-            return new Edge(_pos[i].first, _e.To, capOp.Add(_e.Cap, _re.Cap), _re.Cap, _e.Cost);
+            return new Edge(_pos[i].first, _e.To, op.Add(_e.Cap, _re.Cap), _re.Cap, _e.Cost);
         }
 
         public List<Edge> Edges()
@@ -59,20 +56,20 @@ namespace AtCoder
             return result;
         }
 
-        public (TCap cap, TCost cost) Flow(int s, int t)
+        public (TValue cap, TValue cost) Flow(int s, int t)
         {
-            return flow(s, t, capOp.MaxValue);
+            return flow(s, t, op.MaxValue);
         }
-        public (TCap cap, TCost cost) flow(int s, int t, TCap flow_limit)
+        public (TValue cap, TValue cost) flow(int s, int t, TValue flow_limit)
         {
             return Slope(s, t, flow_limit).Last();
         }
-        public List<(TCap cap, TCost cost)> Slope(int s, int t)
+        public List<(TValue cap, TValue cost)> Slope(int s, int t)
         {
-            return Slope(s, t, capOp.MaxValue);
+            return Slope(s, t, op.MaxValue);
         }
 
-        public List<(TCap cap, TCost cost)> Slope(int s, int t, TCap flow_limit)
+        public List<(TValue cap, TValue cost)> Slope(int s, int t, TValue flow_limit)
         {
             Debug.Assert(0 <= s && s < _n);
             Debug.Assert(0 <= t && t < _n);
@@ -80,15 +77,15 @@ namespace AtCoder
             // variants (C = maxcost):
             // -(n-1)C <= dual[s] <= dual[i] <= dual[t] = 0
             // reduced cost (= e.cost + dual[e.from] - dual[e.to]) >= 0 for all edge
-            var dual = new TCost[_n];
-            var dist = new TCost[_n];
+            var dual = new TValue[_n];
+            var dist = new TValue[_n];
             var pv = new int[_n];
             var pe = new int[_n];
             var vis = new bool[_n];
 
             bool DualRef()
             {
-                dist.AsSpan().Fill(costOp.MaxValue);
+                dist.AsSpan().Fill(op.MaxValue);
                 pv.AsSpan().Fill(-1);
                 pe.AsSpan().Fill(-1);
                 vis.AsSpan().Fill(false);
@@ -108,12 +105,12 @@ namespace AtCoder
                     for (int i = 0; i < _g[v].Count; i++)
                     {
                         var e = _g[v][i];
-                        if(vis[e.To] || capOp.Equals(e.Cap, default)) continue;
+                        if(vis[e.To] || op.Equals(e.Cap, default)) continue;
                         // |-dual[e.to] + dual[v]| <= (n-1)C
                         // cost <= C - -(n-1)C + 0 = nC
-                        TCost cost = costOp.Add(costOp.Subtract(e.Cost, dual[e.To]), dual[v]);
-                        if (costOp.GreaterThan(costOp.Subtract(dist[e.To], dist[v]), cost)) {
-                            dist[e.To] = costOp.Add(dist[v], cost);
+                        TValue cost = op.Add(op.Subtract(e.Cost, dual[e.To]), dual[v]);
+                        if (op.GreaterThan(op.Subtract(dist[e.To], dist[v]), cost)) {
+                            dist[e.To] = op.Add(dist[v], cost);
                             pv[e.To] = v;
                             pe[e.To] = i;
                             que.Enqueue(dist[e.To], e.To);
@@ -133,37 +130,37 @@ namespace AtCoder
                     //         = dual[v] - (shortest(s, t) + dual[s] - dual[t]) + (shortest(s, v) + dual[s] - dual[v])
                     //         = - shortest(s, t) + dual[t] + shortest(s, v)
                     //         = shortest(s, v) - shortest(s, t) >= 0 - (n-1)C
-                    dual[v] = costOp.Subtract(dual[v], costOp.Subtract(dist[t], dist[v]));
+                    dual[v] = op.Subtract(dual[v], op.Subtract(dist[t], dist[v]));
                 }
 
                 return true;
             }
 
-            TCap flow = default;
-            TCost cost = default;
-            TCost prev_cost = costOp.Decrement(default); //-1
-            var result = new List<(TCap cap, TCost cost)>();
+            TValue flow = default;
+            TValue cost = default;
+            TValue prev_cost = op.Decrement(default); //-1
+            var result = new List<(TValue cap, TValue cost)>();
             result.Add((flow, cost));
-            while (capOp.LessThan(flow, flow_limit))
+            while (op.LessThan(flow, flow_limit))
             {
                 if (!DualRef()) break;
-                TCap c = capOp.Subtract(flow_limit, flow);
+                TValue c = op.Subtract(flow_limit, flow);
                 for (int v = t; v != s; v = pv[v])
                 {
-                    if (capOp.LessThan(_g[pv[v]][pe[v]].Cap, c))
+                    if (op.LessThan(_g[pv[v]][pe[v]].Cap, c))
                     {
                         c = _g[pv[v]][pe[v]].Cap;
                     }
                 }
                 for (int v = t; v != s; v = pv[v])
                 {
-                    _g[pv[v]][pe[v]].Cap = capOp.Subtract(_g[pv[v]][pe[v]].Cap, c);
-                    _g[v][_g[pv[v]][pe[v]].Rev].Cap = capOp.Add(_g[v][_g[pv[v]][pe[v]].Rev].Cap, c);
+                    _g[pv[v]][pe[v]].Cap = op.Subtract(_g[pv[v]][pe[v]].Cap, c);
+                    _g[v][_g[pv[v]][pe[v]].Rev].Cap = op.Add(_g[v][_g[pv[v]][pe[v]].Rev].Cap, c);
                 }
-                TCost d = costOp.Minus(dual[s]);
-                flow = capOp.Add(flow, c);
-                cost = costOp.Add(cost, costOp.Multiply(c, d));
-                if (costOp.Equals(prev_cost, d))
+                TValue d = op.Minus(dual[s]);
+                flow = op.Add(flow, c);
+                cost = op.Add(cost, op.Multiply(c, d));
+                if (op.Equals(prev_cost, d))
                 {
                     result.RemoveAt(result.Count - 1);
                 }
@@ -183,12 +180,12 @@ namespace AtCoder
             /// <summary>フローが流入する頂点。</summary>
             public int To { get; set; }
             /// <summary>辺の容量。</summary>
-            public TCap Cap { get; set; }
+            public TValue Cap { get; set; }
             /// <summary>辺の流量。</summary>
-            public TCap Flow { get; set; }
+            public TValue Flow { get; set; }
             /// <summary>辺の費用</summary>
-            public TCost Cost { get; set; }
-            public Edge(int from, int to, TCap cap, TCap flow, TCost cost)
+            public TValue Cost { get; set; }
+            public Edge(int from, int to, TValue cap, TValue flow, TValue cost)
             {
                 From = from;
                 To = to;
@@ -202,9 +199,9 @@ namespace AtCoder
         {
             public int To { get; set; }
             public int Rev { get; set; }
-            public TCap Cap { get; set; }
-            public TCost Cost { get; set; }
-            public EdgeInternal(int to, int rev, TCap cap, TCost cost)
+            public TValue Cap { get; set; }
+            public TValue Cost { get; set; }
+            public EdgeInternal(int to, int rev, TValue cap, TValue cost)
             {
                 To = to;
                 Rev = rev;
@@ -219,20 +216,20 @@ namespace AtCoder
 
         private class PriorityQueueForMcf
         {
-            private (TCost cost, int to)[] _heap;
+            private (TValue cost, int to)[] _heap;
 
             public int Count { get; private set; } = 0;
             public PriorityQueueForMcf()
             {
-                _heap = new (TCost cost, int to)[1024];
+                _heap = new (TValue cost, int to)[1024];
             }
 
-            public void Enqueue(TCost cost, int to)
+            public void Enqueue(TValue cost, int to)
             {
                 var pair = (cost, to);
                 if (_heap.Length == Count)
                 {
-                    var newHeap = new (TCost cost, int to)[_heap.Length * 2];
+                    var newHeap = new (TValue cost, int to)[_heap.Length * 2];
                     _heap.CopyTo(newHeap, 0);
                     _heap = newHeap;
                 }
@@ -258,9 +255,9 @@ namespace AtCoder
                 _heap[c] = pair;
             }
 
-            public (TCost cost, int to) Dequeue()
+            public (TValue cost, int to) Dequeue()
             {
-                (TCost cost, int to) ret = _heap[0];
+                (TValue cost, int to) ret = _heap[0];
                 int n = Count - 1;
 
                 var item = _heap[n];
@@ -292,7 +289,7 @@ namespace AtCoder
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private int Compare(TCost x, TCost y) => costOp.Compare(y, x);
+            private int Compare(TValue x, TValue y) => op.Compare(y, x);
         }
     }
 }


### PR DESCRIPTION
MinCostFlow のライブラリを実装しました。 #15 
また、INumOperator に、 Minus、Increment、Decrement の各関数を追加しました。

流量とコストの型指定について、 #33 の方では方針が完全にはまとまっていないのですが、

- 型が int と long 限定で、それらを混ぜて指定しないといけないケースはほぼ無いと思われる。
- 型パラメーター指定、実装がシンプルになる。
- 最大流のライブラリと同じ interface になる。
- 型指定のラッパーが作りやすい。

といった観点から、流量とコストの型を同一の型 TValue とする方針で実装しています。

動作確認は以下の提出で行いました。
https://atcoder.jp/contests/practice2/submissions/16749137