### PR TITLE
LCPArray修正

### DIFF
--- a/AtCoderLibrary/String/LCPArray.cs
+++ b/AtCoderLibrary/String/LCPArray.cs
@@ -32,7 +32,7 @@ namespace AtCoder
                 int j = sa[rnk[i] - 1];
                 for (; j + h < s.Length && i + h < s.Length; h++)
                 {
-                    if (EqualityComparer<T>.Default.Equals(s[j + h], s[i + h])) break;
+                    if (!EqualityComparer<T>.Default.Equals(s[j + h], s[i + h])) break;
                 }
                 lcp[rnk[i] - 1] = h;
             }


### PR DESCRIPTION
LCPArrayの実装に誤りがあったので修正しました。
LCPArray.cs の 35 行目に

```cs
if (EqualityComparer<T>.Default.Equals(s[j + h], s[i + h])) break;
```

という記述がありますが、元のコードでは

```cpp
if (s[j + h] != s[i + h]) break;
```

となっている部分で、判定が逆になっています。
この判定を元のコードと動作が同じになるように修正しました。

修正後のコードで、 ACL-PC の I問題が通るようになったことを確認しています。
https://atcoder.jp/contests/practice2/submissions/16802009