### PR TITLE
InternalBit.BSF を簡素化

### DIFF
--- a/AtCoderLibrary/Internal/InternalBit.cs
+++ b/AtCoderLibrary/Internal/InternalBit.cs
@@ -34,21 +34,7 @@ namespace AtCoder.Internal
         public static int BSF(uint n)
         {
             Debug.Assert(n >= 1);
-            if (Bmi1.IsSupported)
-            {
-                // O(1)
-                return (int)Bmi1.TrailingZeroCount(n);
-            }
-            else if (Popcnt.IsSupported)
-            {
-                // O(1)
-                return (int)Popcnt.PopCount(~n & (n - 1));
-            }
-            else
-            {
-                // O(logn)
-                return BitOperations.TrailingZeroCount(n);
-            }
+            return BitOperations.TrailingZeroCount(n);
         }
     }
 }


### PR DESCRIPTION
`BitOperations.TrailingZeroCount` の中で `Bmi1.TrailingZeroCount` が呼ばれるので呼び分け不要です。

## Benchmark

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1082 (1909/November2018Update/19H2)
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.401
  [Host]   : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  ShortRun : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT

Job=ShortRun  IterationCount=3  LaunchCount=1
WarmupCount=3

| Method |     Mean |     Error |  StdDev |
|------- |---------:|----------:|--------:|
|   Orig | 726.1 ms | 174.84 ms | 9.58 ms |
|    New | 720.2 ms |  57.55 ms | 3.15 ms |

<details><summary>Coder</summary>

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System.Diagnostics;
using BenchmarkDotNet.Jobs;
using System.Runtime.CompilerServices;
using System.Collections.Generic;
using System;
using System.Numerics;
using System.Linq;
using System.Runtime.Intrinsics.X86;

class Program
{
    static void Main()
    {
        var fastConfig = new ManualConfig();
        fastConfig.Add(DefaultConfig.Instance);
        fastConfig.AddJob(Job.ShortRun);
        BenchmarkRunner.Run<AclBench>(fastConfig);
    }
}
public class AclBench
{
    const int N = 1_000_000;

    [Benchmark]
    public long Orig()
    {
        var rnd = new Random(42);
        long sum = 0;
        for (int i = 0; i < N; i++)
        {
            sum += BSF((uint)rnd.Next());
        }
        return sum;
    }
    [Benchmark]
    public long New()
    {
        var rnd = new Random(42);
        long sum = 0;
        for (int i = 0; i < N; i++)
        {
            sum += BSF2((uint)rnd.Next());
        }
        return sum;
    }
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public static int BSF(uint n)
    {
        Debug.Assert(n >= 1);
        if (Bmi1.IsSupported)
        {
            // O(1)
            return (int)Bmi1.TrailingZeroCount(n);
        }
        else if (Popcnt.IsSupported)
        {
            // O(1)
            return (int)Popcnt.PopCount(~n & (n - 1));
        }
        else
        {
            // O(logn)
            return BitOperations.TrailingZeroCount(n);
        }
    }
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public static int BSF2(uint n)
    {
        Debug.Assert(n >= 1);
        return BitOperations.TrailingZeroCount(n);
    }
}
```

</details>