### PR TITLE
ModIntとConvolutionの高速化

### DIFF
--- a/AtCoderLibrary/Internal/Math/Butterfly.cs
+++ b/AtCoderLibrary/Internal/Math/Butterfly.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace AtCoder.Internal
 {
@@ -18,8 +21,14 @@ namespace AtCoder.Internal
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static void Calculate(Span<StaticModInt<T>> a)
         {
+            CheckPow2(a.Length);
             var n = a.Length;
             var h = InternalMath.CeilPow2(n);
+
+            var regLength = Vector<uint>.Count;
+
+            // 全要素がmodのVector<uint>を作成（比較および加減算用）
+            var modV = new Vector<uint>(default(T).Mod);
 
             for (int ph = 1; ph <= h; ph++)
             {
@@ -31,21 +40,55 @@ namespace AtCoder.Internal
 
                 var now = StaticModInt<T>.Raw(1);
 
+
                 // 各ブロックの s 段目
                 for (int s = 0; s < w; s++)
                 {
                     int offset = s << (h - ph + 1);
-
                     var ls = a.Slice(offset, p);
                     var rs = a.Slice(offset + p, p);
 
-                    for (int i = 0; i < p; i++)
+                    if (p < regLength)
                     {
-                        var l = ls[i];
-                        var r = rs[i] * now;
-                        ls[i] = l + r;
-                        rs[i] = l - r;
+                        for (int i = 0; i < p; i++)
+                        {
+                            var l = ls[i];
+                            var r = rs[i] * now;
+                            ls[i] = l + r;
+                            rs[i] = l - r;
+                        }
                     }
+                    else
+                    {
+                        foreach (ref var r in rs)
+                        {
+                            r *= now;
+                        }
+
+                        // uintとして再解釈
+                        var lu = MemoryMarshal.Cast<StaticModInt<T>, uint>(ls);
+                        var ru = MemoryMarshal.Cast<StaticModInt<T>, uint>(rs);
+
+                        for (int i = 0; i < lu.Length; i += regLength)
+                        {
+                            var luSliced = lu.Slice(i);
+                            var ruSliced = ru.Slice(i);
+                            var u = new Vector<uint>(luSliced);
+                            var v = new Vector<uint>(ruSliced);
+                            var add = u + v;
+                            var sub = u - v;
+
+                            var ge = Vector.GreaterThanOrEqual(add, modV);
+                            add = Vector.ConditionalSelect(ge, add - modV, add);
+
+                            ge = Vector.GreaterThanOrEqual(sub, modV);
+                            sub = Vector.ConditionalSelect(ge, sub + modV, sub);
+
+                            add.CopyTo(luSliced);
+                            sub.CopyTo(ruSliced);
+                        }
+                    }
+
                     now *= sumE[InternalBit.BSF(~(uint)s)];
                 }
             }
@@ -54,8 +97,14 @@ namespace AtCoder.Internal
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static void CalculateInv(Span<StaticModInt<T>> a)
         {
+            CheckPow2(a.Length);
             var n = a.Length;
             var h = InternalMath.CeilPow2(n);
+
+            var regLength = Vector<uint>.Count;
+
+            // 全要素がmodのVector<uint>を作成（比較および加減算用）
+            var modV = new Vector<uint>(default(T).Mod);
 
             for (int ph = h; ph >= 1; ph--)
             {
@@ -75,13 +124,46 @@ namespace AtCoder.Internal
                     var ls = a.Slice(offset, p);
                     var rs = a.Slice(offset + p, p);
 
-                    for (int i = 0; i < p; i++)
+                    if (p < regLength)
                     {
-                        var l = ls[i];
-                        var r = rs[i];
-                        ls[i] = l + r;
-                        rs[i] = StaticModInt<T>.Raw(
-                            (int)((ulong)(default(T).Mod + l.Value - r.Value) * (ulong)iNow.Value % default(T).Mod));
+                        for (int i = 0; i < p; i++)
+                        {
+                            var l = ls[i];
+                            var r = rs[i];
+                            ls[i] = l + r;
+                            rs[i] = StaticModInt<T>.Raw(
+                                (int)((ulong)(default(T).Mod + l.Value - r.Value) * (ulong)iNow.Value % default(T).Mod));
+                        }
+                    }
+                    else
+                    {
+                        // uintとして再解釈
+                        var lu = MemoryMarshal.Cast<StaticModInt<T>, uint>(ls);
+                        var ru = MemoryMarshal.Cast<StaticModInt<T>, uint>(rs);
+
+                        for (int i = 0; i < lu.Length; i += regLength)
+                        {
+                            var luSliced = lu.Slice(i);
+                            var ruSliced = ru.Slice(i);
+                            var u = new Vector<uint>(luSliced);
+                            var v = new Vector<uint>(ruSliced);
+                            var add = u + v;
+                            var sub = u - v;
+
+                            var ge = Vector.GreaterThanOrEqual(add, modV);
+                            add = Vector.ConditionalSelect(ge, add - modV, add);
+
+                            // こちらは後で余りを取るのでマスク不要
+                            sub += modV;
+
+                            add.CopyTo(luSliced);
+                            sub.CopyTo(ruSliced);
+                        }
+
+                        foreach (ref var r in rs)
+                        {
+                            r *= iNow;
+                        }
                     }
                     iNow *= sumIE[InternalBit.BSF(~(uint)s)];
                 }
@@ -150,6 +232,15 @@ namespace AtCoder.Internal
             }
 
             return sumIE;
+        }
+
+        [Conditional("DEBUG")]
+        private static void CheckPow2(int n)
+        {
+            if (BitOperations.PopCount((uint)n) != 1)
+            {
+                throw new ArgumentException("配列長は2のべき乗でなければなりません。");
+            }
         }
     }
 }

--- a/AtCoderLibrary/Internal/Math/Butterfly.cs
+++ b/AtCoderLibrary/Internal/Math/Butterfly.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace AtCoder.Internal
 {
@@ -14,6 +15,7 @@ namespace AtCoder.Internal
         /// </summary>
         private static StaticModInt<T>[] sumIE = CalcurateSumIE();
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static void Calculate(Span<StaticModInt<T>> a)
         {
             var n = a.Length;
@@ -34,18 +36,22 @@ namespace AtCoder.Internal
                 {
                     int offset = s << (h - ph + 1);
 
+                    var ls = a.Slice(offset, p);
+                    var rs = a.Slice(offset + p, p);
+
                     for (int i = 0; i < p; i++)
                     {
-                        var l = a[i + offset];
-                        var r = a[i + offset + p] * now;
-                        a[i + offset] = l + r;
-                        a[i + offset + p] = l - r;
+                        var l = ls[i];
+                        var r = rs[i] * now;
+                        ls[i] = l + r;
+                        rs[i] = l - r;
                     }
                     now *= sumE[InternalBit.BSF(~(uint)s)];
                 }
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public static void CalculateInv(Span<StaticModInt<T>> a)
         {
             var n = a.Length;
@@ -66,13 +72,16 @@ namespace AtCoder.Internal
                 {
                     int offset = s << (h - ph + 1);
 
+                    var ls = a.Slice(offset, p);
+                    var rs = a.Slice(offset + p, p);
+
                     for (int i = 0; i < p; i++)
                     {
-                        var l = a[i + offset];
-                        var r = a[i + offset + p];
-                        a[i + offset] = l + r;
-                        a[i + offset + p] = StaticModInt<T>.Raw(
-                            unchecked((int)((ulong)(default(T).Mod + l.Value - r.Value) * (ulong)iNow.Value % default(T).Mod)));
+                        var l = ls[i];
+                        var r = rs[i];
+                        ls[i] = l + r;
+                        rs[i] = StaticModInt<T>.Raw(
+                            (int)((ulong)(default(T).Mod + l.Value - r.Value) * (ulong)iNow.Value % default(T).Mod));
                     }
                     iNow *= sumIE[InternalBit.BSF(~(uint)s)];
                 }

--- a/AtCoderLibrary/Math/ModInt.cs
+++ b/AtCoderLibrary/Math/ModInt.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace AtCoder
 {
@@ -90,6 +91,7 @@ namespace AtCoder
         /// <para>定数倍高速化のための関数です。 <paramref name="v"/> に 0 未満または mod 以上の値を入れた場合の挙動は未定義です。</para>
         /// <para>制約: 0≤|<paramref name="v"/>|&lt;mod</para>
         /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static StaticModInt<T> Raw(int v)
         {
             var u = unchecked((uint)v);
@@ -107,6 +109,7 @@ namespace AtCoder
 
         private StaticModInt(uint v) => _v = v;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint Round(long v)
         {
             var x = v % default(T).Mod;
@@ -117,6 +120,7 @@ namespace AtCoder
             return (uint)x;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static StaticModInt<T> operator++(StaticModInt<T> value)
         {
             var v = value._v + 1;
@@ -127,6 +131,7 @@ namespace AtCoder
             return new StaticModInt<T>(v);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static StaticModInt<T> operator--(StaticModInt<T> value)
         {
             var v = value._v;
@@ -137,6 +142,7 @@ namespace AtCoder
             return new StaticModInt<T>(v - 1);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static StaticModInt<T> operator +(StaticModInt<T> lhs, StaticModInt<T> rhs)
         {
             var v = lhs._v + rhs._v;
@@ -147,6 +153,7 @@ namespace AtCoder
             return new StaticModInt<T>(v);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static StaticModInt<T> operator -(StaticModInt<T> lhs, StaticModInt<T> rhs)
         {
             unchecked
@@ -160,6 +167,7 @@ namespace AtCoder
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static StaticModInt<T> operator *(StaticModInt<T> lhs, StaticModInt<T> rhs)
         {
             return new StaticModInt<T>((uint)((ulong)lhs._v * rhs._v % default(T).Mod));
@@ -192,7 +200,7 @@ namespace AtCoder
         {
             Debug.Assert(0 <= n);
             var x = this;
-            var r = new StaticModInt<T>(1u);
+            var r = Raw(1);
 
             while (n > 0)
             {
@@ -213,6 +221,7 @@ namespace AtCoder
         /// <remarks>
         /// <para>制約: gcd(x, mod) = 1</para>
         /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public StaticModInt<T> Inv()
         {
             if (default(T).IsPrime)
@@ -283,6 +292,7 @@ namespace AtCoder
         /// <para>定数倍高速化のための関数です。 <paramref name="v"/> に 0 未満または mod 以上の値を入れた場合の挙動は未定義です。</para>
         /// <para>制約: 0≤|<paramref name="v"/>|&lt;mod</para>
         /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DynamicModInt<T> Raw(int v)
         {
             var u = unchecked((uint)v);
@@ -302,6 +312,7 @@ namespace AtCoder
 
         private DynamicModInt(uint v) => _v = v;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint Round(long v)
         {
             Debug.Assert(bt != null, $"使用前に {nameof(DynamicModInt<T>)}<{nameof(T)}>.{nameof(Mod)} プロパティに mod の値を設定してください。");
@@ -313,6 +324,7 @@ namespace AtCoder
             return (uint)x;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DynamicModInt<T> operator ++(DynamicModInt<T> value)
         {
             var v = value._v + 1;
@@ -323,6 +335,7 @@ namespace AtCoder
             return new DynamicModInt<T>(v);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DynamicModInt<T> operator --(DynamicModInt<T> value)
         {
             var v = value._v;
@@ -333,6 +346,7 @@ namespace AtCoder
             return new DynamicModInt<T>(v - 1);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DynamicModInt<T> operator +(DynamicModInt<T> lhs, DynamicModInt<T> rhs)
         {
             var v = lhs._v + rhs._v;
@@ -343,6 +357,7 @@ namespace AtCoder
             return new DynamicModInt<T>(v);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DynamicModInt<T> operator -(DynamicModInt<T> lhs, DynamicModInt<T> rhs)
         {
             unchecked
@@ -356,6 +371,7 @@ namespace AtCoder
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DynamicModInt<T> operator *(DynamicModInt<T> lhs, DynamicModInt<T> rhs)
         {
             uint z = bt.Mul(lhs._v, rhs._v);
@@ -389,7 +405,7 @@ namespace AtCoder
         {
             Debug.Assert(0 <= n);
             var x = this;
-            var r = new DynamicModInt<T>(1u);
+            var r = Raw(1);
 
             while (n > 0)
             {
@@ -410,6 +426,7 @@ namespace AtCoder
         /// <remarks>
         /// <para>制約: gcd(x, mod) = 1</para>
         /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public DynamicModInt<T> Inv()
         {
             var (g, x) = Internal.InternalMath.InvGCD(_v, bt.Mod);

--- a/AtCoderLibrary/Math/ModInt.cs
+++ b/AtCoderLibrary/Math/ModInt.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace AtCoder
@@ -70,7 +71,7 @@ namespace AtCoder
     /// }
     /// </code>
     /// </example>
-    public readonly struct StaticModInt<T> where T : struct, IStaticMod
+    public readonly struct StaticModInt<T> : IEquatable<StaticModInt<T>> where T : struct, IStaticMod
     {
         private readonly uint _v;
 
@@ -238,7 +239,8 @@ namespace AtCoder
         }
 
         public override string ToString() => _v.ToString();
-        public override bool Equals(object obj) => obj is StaticModInt<T> && this == (StaticModInt<T>)obj;
+        public override bool Equals(object obj) => obj is StaticModInt<T> && Equals((StaticModInt<T>)obj);
+        public bool Equals(StaticModInt<T> other) => Value == other.Value;
         public override int GetHashCode() => _v.GetHashCode();
     }
 
@@ -262,7 +264,7 @@ namespace AtCoder
     /// }
     /// </code>
     /// </example>
-    public readonly struct DynamicModInt<T> where T : struct, IDynamicModID
+    public readonly struct DynamicModInt<T> : IEquatable<DynamicModInt<T>> where T : struct, IDynamicModID
     {
         private readonly uint _v;
         private static Internal.Barrett bt;
@@ -435,7 +437,8 @@ namespace AtCoder
         }
 
         public override string ToString() => _v.ToString();
-        public override bool Equals(object obj) => obj is DynamicModInt<T> && this == (DynamicModInt<T>)obj;
+        public override bool Equals(object obj) => obj is DynamicModInt<T> && Equals((DynamicModInt<T>)obj);
+        public bool Equals(DynamicModInt<T> other) => Value == other.Value;
         public override int GetHashCode() => _v.GetHashCode();
     }
 }


### PR DESCRIPTION
`ModInt`と`Convolution`の高速化を行いました。

JITが吐き出したアセンブリを覗いてみたところ、Releaseビルドでも思いのほかインライン化をしてくれていなかったので、
`ModInt`のメソッド類にひたすら`MethodImplOptions.AggressiveInlining`を付与しています。
（1ステートメントで済むもの、およびループを含む`Pow`は除く。）
ついでではあるのですが、もともと`==`演算子がオーバーロードされていたことを踏まえ、`IEquatable<T>`を実装しています。

また、`Convolution`については一部`Span`を使い境界チェックを省略させることで高速化を図っています。
単に`Span`を使っただけだとJITコンパイラの最適化が甘いせいかジャッジ環境でむしろ遅くなってしまった（複数回再現）ため、メソッドに`MethodImplOptions.AggressiveOptimization`を付与しています。
（これは想像ですが、`Convolution`は重い処理のメソッドを1,2回しか呼ばないため、[Tiered Compilation](https://ufcpp.net/blog/2018/12/tieredcompilation/)において最適化不要と判断されてしまったのかもしれません。）

サンプル数が少ないのでデータの信頼性はアレですが、ACL Practice Contest Fで実行時間の比較をしています。
（手元環境でも比較はしていますが、特に`AggressiveOptimization`周りは若干傾向が異なっていました。入出力に時間がかかった場合に[Tiered Compilationのタイマーが時間切れになってしまう](https://github.com/dotnet/runtime/blob/master/docs/design/features/tiered-compilation.md)可能性があるかもしれないと思っているのですが、よく分かっていません……。）

### `ModInt`
いずれも`Convolution`は`Span`なし、`AggressiveOptimization`なしの状態です。
|`AggressiveInlining`|実行時間|
|:-------------------:|:--------:|
|なし                       |[789 ms](https://atcoder.jp/contests/practice2/submissions/16940666)|
|あり                       |[644 ms](https://atcoder.jp/contests/practice2/submissions/16941503)|

### `Convolution`
いずれも`ModInt`は`AggressiveInlining`ありの状態です。
|                                               |`Span`なし|`Span`あり|
|:-------------------------------:|:-----------:|:-----------:|
|`AggressiveOptimization`なし|[644 ms](https://atcoder.jp/contests/practice2/submissions/16941503)|[698 ms](https://atcoder.jp/contests/practice2/submissions/16941591)|
|`AggressiveOptimization`あり|[644 ms](https://atcoder.jp/contests/practice2/submissions/16941535)|[627 ms](https://atcoder.jp/contests/practice2/submissions/16941610)|

手元環境での`Convolution`の`Span`有無によるベンチマーク結果は以下です。
境界チェックがいくつか外れる程度なので大きな効果ではないのですが、1～2%程度は高速化されているのかなという印象です。
（いずれも`ModInt`は`AggressiveInlining`あり、`Convolution`は`AggressiveOptimization`あり。）

```
// * Summary *

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1082 (1909/November2018Update/19H2)
Intel Core i7-8700K CPU 3.70GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.300
  [Host]     : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
  Job-THGFLZ : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT

MinIterationCount=50
```

|            Method |       N |         Mean |      Error |     StdDev |
|------------------ |--------:|-------------:|-----------:|-----------:|
| ConvolutionNormal |    1024 |     16.78 us |   0.079 us |   0.151 us |
|   ConvolutionSpan |    1024 |     16.56 us |   0.045 us |   0.086 us |
| ConvolutionNormal |   32768 |    747.22 us |   2.815 us |   5.423 us |
|   ConvolutionSpan |   32768 |    732.66 us |   2.902 us |   5.591 us |
| ConvolutionNormal | 1048576 | 31,071.89 us | 135.036 us | 272.779 us |
|   ConvolutionSpan | 1048576 | 30,574.61 us | 152.717 us | 304.993 us |

<details>
<summary>ベンチマークコード（一部抜粋）</summary>

```C#
using System;
using System.Collections.Generic;
using System.Diagnostics;
using System.Numerics;
using System.Runtime.CompilerServices;
using System.Runtime.Intrinsics.X86;
using AtCoder;
using AtCoder.Internal;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

namespace ConsoleApp29
{
    class Program
    {
        static void Main(string[] args)
        {
            BenchmarkRunner.Run<ConvolutionTest>();
        }
    }

    [MinIterationCount(50)]
    public class ConvolutionTest
    {
        [Params(1024, 32768, 1048576)]
        public int N { get; set; }

        private StaticModInt<Mod998244353>[] _workspace;

        [GlobalSetup]
        public void SetUp()
        {   
            _workspace = new StaticModInt<Mod998244353>[N];
        }

        [Benchmark]
        public void ConvolutionNormal()
        {
            Butterfly<Mod998244353>.Calculate(_workspace);
        }

        [Benchmark]
        public void ConvolutionSpan()
        {
            ButterflySpan<Mod998244353>.Calculate(_workspace);
        }
    }
}

namespace AtCoder.Internal
{
    public static class Butterfly<T> where T : struct, IStaticMod
    {
        /// <summary>
        /// sumE[i] = ies[0] * ... * ies[i - 1] * es[i]
        /// </summary>
        private static StaticModInt<T>[] sumE = CalcurateSumE();

        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
        public static void Calculate(Span<StaticModInt<T>> a)
        {
            var n = a.Length;
            var h = InternalMath.CeilPow2(n);
            for (int ph = 1; ph <= h; ph++)
            {
                // ブロックサイズの半分
                int w = 1 << (ph - 1);

                // ブロック数
                int p = 1 << (h - ph);

                var now = StaticModInt<T>.Raw(1);

                // 各ブロックの s 段目
                for (int s = 0; s < w; s++)
                {
                    int offset = s << (h - ph + 1);

                    for (int i = 0; i < p; i++)
                    {
                        var l = a[i + offset];
                        var r = a[i + offset + p] * now;
                        a[i + offset] = l + r;
                        a[i + offset + p] = l - r;
                    }
                    now *= sumE[InternalBit.BSF(~(uint)s)];
                }
            }
        }

        private static StaticModInt<T>[] CalcurateSumE()
        {
            int g = InternalMath.PrimitiveRoot((int)default(T).Mod);
            int cnt2 = InternalBit.BSF(default(T).Mod - 1);
            var e = new StaticModInt<T>(g).Pow((default(T).Mod - 1) >> cnt2);
            var ie = e.Inv();

            var sumE = new StaticModInt<T>[cnt2 - 2];

            // es[i]^(2^(2+i)) == 1
            Span<StaticModInt<T>> es = stackalloc StaticModInt<T>[cnt2 - 1];
            Span<StaticModInt<T>> ies = stackalloc StaticModInt<T>[cnt2 - 1];

            for (int i = es.Length - 1; i >= 0; i--)
            {
                // e^(2^(2+i)) == 1
                es[i] = e;
                ies[i] = ie;
                e *= e;
                ie *= ie;
            }

            var now = StaticModInt<T>.Raw(1);
            for (int i = 0; i < sumE.Length; i++)
            {
                sumE[i] = es[i] * now;
                now *= ies[i];
            }

            return sumE;
        }
    }

    public static class ButterflySpan<T> where T : struct, IStaticMod
    {
        /// <summary>
        /// sumE[i] = ies[0] * ... * ies[i - 1] * es[i]
        /// </summary>
        private static StaticModInt<T>[] sumE = CalcurateSumE();

        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
        public static void Calculate(Span<StaticModInt<T>> a)
        {
            var n = a.Length;
            var h = InternalMath.CeilPow2(n);

            for (int ph = 1; ph <= h; ph++)
            {
                // ブロックサイズの半分
                int w = 1 << (ph - 1);

                // ブロック数
                int p = 1 << (h - ph);

                var now = StaticModInt<T>.Raw(1);

                // 各ブロックの s 段目
                for (int s = 0; s < w; s++)
                {
                    int offset = s << (h - ph + 1);
                    var ls = a.Slice(offset, p);
                    var rs = a.Slice(offset + p, p);

                    for (int i = 0; i < p; i++)
                    {
                        var l = ls[i];
                        var r = rs[i] * now;
                        ls[i] = l + r;
                        rs[i] = l - r;
                    }
                    now *= sumE[InternalBit.BSF(~(uint)s)];
                }
            }
        }

        private static StaticModInt<T>[] CalcurateSumE()
        {
            int g = InternalMath.PrimitiveRoot((int)default(T).Mod);
            int cnt2 = InternalBit.BSF(default(T).Mod - 1);
            var e = new StaticModInt<T>(g).Pow((default(T).Mod - 1) >> cnt2);
            var ie = e.Inv();

            var sumE = new StaticModInt<T>[cnt2 - 2];

            // es[i]^(2^(2+i)) == 1
            Span<StaticModInt<T>> es = stackalloc StaticModInt<T>[cnt2 - 1];
            Span<StaticModInt<T>> ies = stackalloc StaticModInt<T>[cnt2 - 1];

            for (int i = es.Length - 1; i >= 0; i--)
            {
                // e^(2^(2+i)) == 1
                es[i] = e;
                ies[i] = ie;
                e *= e;
                ie *= ie;
            }

            var now = StaticModInt<T>.Raw(1);
            for (int i = 0; i < sumE.Length; i++)
            {
                sumE[i] = es[i] * now;
                now *= ies[i];
            }

            return sumE;
        }
    }
}

// 以下略
```

</details>